### PR TITLE
Migrate to Azure Cloudshell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com\azure-cloudshell@sha256:075eadba1d78d537fa188fe82d4bc0f6e552ab3416d60c0b43bff5fd5372535e
+FROM mcr.microsoft.com/azure-cloudshell@sha256:075eadba1d78d537fa188fe82d4bc0f6e552ab3416d60c0b43bff5fd5372535e
 
 COPY ./Login.ps1 /etc/util-scripts/Login.ps1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG DOCKER_VERSION="18.03.1"
 ARG DOCKER_URI="https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}-ce.tgz"
 ARG DOCKER_GID="412"
 
-RUN apk --no-cache add curl && \
+RUN apt install curl && \
     curl ${DOCKER_URI} -o /tmp/docker-${DOCKER_VERSION}.tgz && \
     cd /tmp && \
     tar -xvzf /tmp/docker-${DOCKER_VERSION}.tgz docker/docker && \
@@ -17,8 +17,8 @@ RUN apk --no-cache add curl && \
     rm -v /tmp/docker-${DOCKER_VERSION}.tgz && \
     chmod -v +x ${DOCKER_PATH}/docker
 
-RUN addgroup -S -g ${DOCKER_GID} docker && \
-    adduser -S -G docker docker && \
-    adduser -G docker -u 1000 -D jenkins
+RUN addgroup --system --gid ${DOCKER_GID} docker && \
+    adduser --system --ingroup docker docker && \
+    adduser --ingroup docker -u 1000 --disabled-password jenkins
 
 RUN chmod +x /etc/util-scripts/Login.ps1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.1.0-alpine-3.12-20201116
+FROM mcr.microsoft.com\azure-cloudshell@sha256:075eadba1d78d537fa188fe82d4bc0f6e552ab3416d60c0b43bff5fd5372535e
 
 COPY ./Login.ps1 /etc/util-scripts/Login.ps1
 
@@ -21,5 +21,4 @@ RUN addgroup -S -g ${DOCKER_GID} docker && \
     adduser -S -G docker docker && \
     adduser -G docker -u 1000 -D jenkins
 
-RUN pwsh -command 'Install-Module -Name Az -AllowClobber -Scope CurrentUser -Force -RequiredVersion 4.2.0' && \
-    chmod +x /etc/util-scripts/Login.ps1
+RUN chmod +x /etc/util-scripts/Login.ps1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-library 'jenkins-ptcs-library@3.0.0'
+library 'jenkins-ptcs-library@4.0.3'
 
 podTemplate(label: pod.label,
     containers: pod.templates

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
 # azure-ci-container
 
-Since <https://hub.docker.com/r/azuresdk/azure-powershell-core> is not supported and broken
-we use extended self built image for CI.
-
-## Tools
-
-- Powershell 7
-- Powershell AZ module
+https://github.com/Azure/CloudShell with docker in docker -support.


### PR DESCRIPTION
Azure Cloudshell-container should now work for this, so we don't need to install Az-module separately anymore.